### PR TITLE
Remove branch filters

### DIFF
--- a/.github/workflows/kotlin-samples-CI.yml
+++ b/.github/workflows/kotlin-samples-CI.yml
@@ -16,7 +16,7 @@ on:
         required: false
 
 jobs:
-  build:
+  buuild-test-and-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/kotlin-samples-CI.yml
+++ b/.github/workflows/kotlin-samples-CI.yml
@@ -5,9 +5,7 @@ name: Kotlin samples CI
 
 on:
   push:
-    branches: [ develop, master ]
   pull_request:
-    branches: [ develop, master ]
   workflow_dispatch:
     inputs:
       name:

--- a/.github/workflows/kotlin-samples-CI.yml
+++ b/.github/workflows/kotlin-samples-CI.yml
@@ -16,7 +16,7 @@ on:
         required: false
 
 jobs:
-  buuild-test-and-check:
+  build-test-and-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/kotlin-samples-CI.yml
+++ b/.github/workflows/kotlin-samples-CI.yml
@@ -5,6 +5,7 @@ name: Kotlin samples CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Remove branch filters in order to run checks on every PR or push no matter the target branch.