### PR TITLE
Refactoring workflow's 'on' section

### DIFF
--- a/.github/workflows/kotlin-samples-CI.yml
+++ b/.github/workflows/kotlin-samples-CI.yml
@@ -4,9 +4,9 @@
 name: Kotlin samples CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
+    branches: [ main, release ]
   workflow_dispatch:
     inputs:
       name:


### PR DESCRIPTION
Moving pull_request to the top (it could be that the order matters), and added release to the on push branches.